### PR TITLE
Fix problem with santitize options on modern versions of gcc

### DIFF
--- a/Microsoft.WindowsAzure.Storage/includes/was/core.h
+++ b/Microsoft.WindowsAzure.Storage/includes/was/core.h
@@ -1097,7 +1097,7 @@ namespace azure { namespace storage {
         utility::string_t m_content_md5;
         utility::string_t m_content_crc64;
         utility::string_t m_etag;
-        bool m_request_server_encrypted;
+        bool m_request_server_encrypted = false;
         storage_extended_error m_extended_error;
     };
 


### PR DESCRIPTION
Some of the constructors for request_result do not initialize the value
leading to complaints when the copy constructor is used.

Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>